### PR TITLE
Potential security issue in src/protocol/survey0/survey.c: Unchecked return from initialization function

### DIFF
--- a/src/protocol/survey0/survey.c
+++ b/src/protocol/survey0/survey.c
@@ -452,6 +452,7 @@ surv0_pipe_recv_cb(void *arg)
 	surv0_pipe *p    = arg;
 	surv0_sock *sock = p->sock;
 	surv0_ctx * ctx;
+  ctx = {};
 	nni_msg *   msg;
 	uint32_t    id;
 	nni_aio *   aio;


### PR DESCRIPTION
<span> What is a&nbsp;</span><span><b>Conditionally Uninitialized Variable? </b></span><span> When an initialization function is used to initialize a local variable, but the returned status code is not checked, reading the variable may result in undefined behaviour.</span>
---

1 instance of this defect were found in the following locations:
---
**Instance 1**
File : `src/protocol/survey0/survey.c` 
Function: `nni_list_remove` 
https://github.com/siva-msft/nng/blob/d093bb33c22a07c8aa922839741a72781cc7fda3/src/protocol/survey0/survey.c#L485
Code extract:

```cpp
	    (nni_lmq_full(&ctx->recv_lmq))) {
		nni_msg_free(msg);
	} else if ((aio = nni_list_first(&ctx->recv_queue)) != NULL) {
		nni_list_remove(&ctx->recv_queue, aio); <------ HERE
		nni_aio_finish_msg(aio, msg);
	} else {
```

