### PR TITLE
Potential security issue in tests/ipcsupp.c: Unchecked return from initialization function

### DIFF
--- a/tests/ipcsupp.c
+++ b/tests/ipcsupp.c
@@ -20,6 +20,7 @@ static int num = 0;
 
 TestMain("Supplemental IPC", {
 	atexit(nng_fini);
+iov = {};
 	Convey("We can create a dialer and listener", {
 		nng_stream_dialer *  d;
 		nng_stream_listener *l;


### PR DESCRIPTION
<span> What is a&nbsp;</span><span><b>Conditionally Uninitialized Variable? </b></span><span> When an initialization function is used to initialize a local variable, but the returned status code is not checked, reading the variable may result in undefined behaviour.</span>
---

1 instance of this defect were found in the following locations:
---
**Instance 1**
File : `tests/ipcsupp.c` 
Function: `nng_aio_set_iov` 
https://github.com/siva-msft/nng/blob/d093bb33c22a07c8aa922839741a72781cc7fda3/tests/ipcsupp.c#L21
Code extract:

```cpp

static int num = 0;

TestMain("Supplemental IPC", { <------ HERE
	atexit(nng_fini);
	Convey("We can create a dialer and listener", {
```

