### PR TITLE
Potential security issue in tests/tcpsupp.c: Unchecked return from initialization function

### DIFF
--- a/tests/tcpsupp.c
+++ b/tests/tcpsupp.c
@@ -17,6 +17,7 @@
 
 TestMain("Supplemental TCP", {
 	atexit(nng_fini);
+iov = {};
 	Convey("We can create a dialer and listener", {
 		nng_stream_dialer *  d = NULL;
 		nng_stream_listener *l = NULL;


### PR DESCRIPTION
<span> What is a&nbsp;</span><span><b>Conditionally Uninitialized Variable? </b></span><span> When an initialization function is used to initialize a local variable, but the returned status code is not checked, reading the variable may result in undefined behaviour.</span>
---

1 instance of this defect were found in the following locations:
---
**Instance 1**
File : `tests/tcpsupp.c` 
Function: `nng_aio_set_iov` 
https://github.com/siva-msft/nng/blob/d093bb33c22a07c8aa922839741a72781cc7fda3/tests/tcpsupp.c#L18
Code extract:

```cpp
#include "convey.h"
#include "stubs.h"

TestMain("Supplemental TCP", { <------ HERE
	atexit(nng_fini);
	Convey("We can create a dialer and listener", {
```

