### PR TITLE
Potential security issue in tests/ipcsupp.c: Unchecked return from initialization function

### DIFF
--- a/tests/ipcsupp.c
+++ b/tests/ipcsupp.c
@@ -20,6 +20,7 @@ static int num = 0;
 
 TestMain("Supplemental IPC", {
 	atexit(nng_fini);
+	iov = {};
 	Convey("We can create a dialer and listener", {
 		nng_stream_dialer *  d;
 		nng_stream_listener *l;


### PR DESCRIPTION
<span> What is a&nbsp;</span><span><b>Conditionally Uninitialized Variable? </b></span><span> The return value of a function that is potentially used to initialize a local variable is not checked. Therefore, reading the local variable may result in undefined behavior.</span>
---

1 instance of this defect were found in the following locations:
---
**Instance 1**
File : `tests/ipcsupp.c` 
Function: `nng_aio_set_iov` 
https://github.com/siva-msft/nng/blob/e16900a421babead1979838c0521eb25e8020fea/tests/ipcsupp.c#L21
Code extract:

```cpp

static int num = 0;

TestMain("Supplemental IPC", { <------ HERE
	atexit(nng_fini);
	Convey("We can create a dialer and listener", {
```

