### PR TITLE
Potential security issue in tests/tcpsupp.c: Unchecked return from initialization function

### DIFF
--- a/tests/tcpsupp.c
+++ b/tests/tcpsupp.c
@@ -17,6 +17,7 @@
 
 TestMain("Supplemental TCP", {
 	atexit(nng_fini);
+	iov = {};
 	Convey("We can create a dialer and listener", {
 		nng_stream_dialer *  d = NULL;
 		nng_stream_listener *l = NULL;


### PR DESCRIPTION
<span> What is a&nbsp;</span><span><b>Conditionally Uninitialized Variable? </b></span><span> The return value of a function that is potentially used to initialize a local variable is not checked. Therefore, reading the local variable may result in undefined behavior.</span>
---

1 instance of this defect were found in the following locations:
---
**Instance 1**
File : `tests/tcpsupp.c` 
Function: `nng_aio_set_iov` 
https://github.com/siva-msft/nng/blob/e16900a421babead1979838c0521eb25e8020fea/tests/tcpsupp.c#L18
Code extract:

```cpp
#include "convey.h"
#include "stubs.h"

TestMain("Supplemental TCP", { <------ HERE
	atexit(nng_fini);
	Convey("We can create a dialer and listener", {
```

