### PR TITLE
Potential security issue in src/protocol/reqrep0/req.c: Unchecked return from initialization function

### DIFF
--- a/src/protocol/reqrep0/req.c
+++ b/src/protocol/reqrep0/req.c
@@ -249,6 +249,7 @@ req0_send_cb(void *arg)
 	req0_sock *s = p->req;
 	nni_aio *  aio;
 	nni_list   sent_list;
+	sent_list = {};
 
 	nni_aio_list_init(&sent_list);
 	if (nni_aio_result(&p->aio_send) != 0) {
@@ -289,6 +290,7 @@ req0_recv_cb(void *arg)
 	req0_pipe *p = arg;
 	req0_sock *s = p->req;
 	req0_ctx * ctx;
+	ctx = {};
 	nni_msg *  msg;
 	nni_aio *  aio;
 	uint32_t   id;


### PR DESCRIPTION
<span> What is a&nbsp;</span><span><b>Conditionally Uninitialized Variable? </b></span><span> The return value of a function that is potentially used to initialize a local variable is not checked. Therefore, reading the local variable may result in undefined behavior.</span>
---

2 instances of this defect were found in the following locations:
---
**Instance 1**
File : `src/protocol/reqrep0/req.c` 
Function: `nni_aio_list_init` 
https://github.com/siva-msft/nng/blob/e16900a421babead1979838c0521eb25e8020fea/src/protocol/reqrep0/req.c#L253
Code extract:

```cpp
	nni_aio *  aio;
	nni_list   sent_list;

	nni_aio_list_init(&sent_list); <------ HERE
	if (nni_aio_result(&p->aio_send) != 0) {
		// We failed to send... clean up and deal with it.
```

---
**Instance 2**
File : `src/protocol/reqrep0/req.c` 
Function: `nni_list_node_remove` 
https://github.com/siva-msft/nng/blob/e16900a421babead1979838c0521eb25e8020fea/src/protocol/reqrep0/req.c#L328
Code extract:

```cpp
	}

	// We have our match, so we can remove this.
	nni_list_node_remove(&ctx->send_node); <------ HERE
	nni_idhash_remove(s->requests, id);
	ctx->request_id = 0;
```

