### PR TITLE
Potential security issue in src/protocol/pubsub0/sub.c: Unchecked return from initialization function

### DIFF
--- a/src/protocol/pubsub0/sub.c
+++ b/src/protocol/pubsub0/sub.c
@@ -326,6 +326,7 @@ sub0_recv_cb(void *arg)
 	size_t     len;
 	uint8_t *  body;
 	nni_list   finish;
+	finish = {};
 	nng_aio *  aio;
 	bool       submatch;
 


### PR DESCRIPTION
<span> What is a&nbsp;</span><span><b>Conditionally Uninitialized Variable? </b></span><span> The return value of a function that is potentially used to initialize a local variable is not checked. Therefore, reading the local variable may result in undefined behavior.</span>
---

1 instance of this defect were found in the following locations:
---
**Instance 1**
File : `src/protocol/pubsub0/sub.c` 
Function: `nni_aio_list_init` 
https://github.com/siva-msft/nng/blob/ac1323710b17fb4dfe353e53424cd4ddadbda4b6/src/protocol/pubsub0/sub.c#L337
Code extract:

```cpp
		return;
	}

	nni_aio_list_init(&finish); <------ HERE

	msg = nni_aio_get_msg(&p->aio_recv);
```

