### PR TITLE
Potential security issue in src/protocol/reqrep0/rep.c: Unchecked return from initialization function

### DIFF
--- a/src/protocol/reqrep0/rep.c
+++ b/src/protocol/reqrep0/rep.c
@@ -132,6 +132,7 @@ rep0_ctx_send(void *arg, nni_aio *aio)
 	rep0_ctx * ctx = arg;
 	rep0_sock *s   = ctx->sock;
 	rep0_pipe *p;
+	p = {};
 	nni_msg *  msg;
 	int        rv;
 	size_t     len;


### PR DESCRIPTION
<span> What is a&nbsp;</span><span><b>Conditionally Uninitialized Variable? </b></span><span> The return value of a function that is potentially used to initialize a local variable is not checked. Therefore, reading the local variable may result in undefined behavior.</span>
---

1 instance of this defect were found in the following locations:
---
**Instance 1**
File : `src/protocol/reqrep0/rep.c` 
Function: `nni_aio_set_msg` 
https://github.com/siva-msft/nng/blob/ac1323710b17fb4dfe353e53424cd4ddadbda4b6/src/protocol/reqrep0/rep.c#L192
Code extract:

```cpp
	if (!p->busy) {
		p->busy = true;
		len     = nni_msg_len(msg);
		nni_aio_set_msg(&p->aio_send, msg); <------ HERE
		nni_pipe_send(p->pipe, &p->aio_send);
		nni_mtx_unlock(&s->lk);
```

