### PR TITLE
Potential security issue in src/protocol/survey0/respond.c: Unchecked return from initialization function

### DIFF
--- a/src/protocol/survey0/respond.c
+++ b/src/protocol/survey0/respond.c
@@ -142,6 +142,7 @@ resp0_ctx_send(void *arg, nni_aio *aio)
 	resp0_ctx * ctx = arg;
 	resp0_sock *s   = ctx->sock;
 	resp0_pipe *p;
+	p = {};
 	nni_msg *   msg;
 	size_t      len;
 	uint32_t    pid;


### PR DESCRIPTION
<span> What is a&nbsp;</span><span><b>Conditionally Uninitialized Variable? </b></span><span> The return value of a function that is potentially used to initialize a local variable is not checked. Therefore, reading the local variable may result in undefined behavior.</span>
---

1 instance of this defect were found in the following locations:
---
**Instance 1**
File : `src/protocol/survey0/respond.c` 
Function: `nni_aio_set_msg` 
https://github.com/siva-msft/nng/blob/ac1323710b17fb4dfe353e53424cd4ddadbda4b6/src/protocol/survey0/respond.c#L195
Code extract:

```cpp
	if (!p->busy) {
		p->busy = true;
		len     = nni_msg_len(msg);
		nni_aio_set_msg(&p->aio_send, msg); <------ HERE
		nni_pipe_send(p->npipe, &p->aio_send);
		nni_mtx_unlock(&s->mtx);
```

