### PR TITLE
Potential security issue in src/compat/nanomsg/nn.c: Missing pointer dereference in sizeof

### DIFF
--- a/src/compat/nanomsg/nn.c
+++ b/src/compat/nanomsg/nn.c
@@ -336,7 +336,7 @@ nn_allocmsg(size_t size, int type)
 
 	// We are counting on the implementation of nn_msg_trim to not
 	// reallocate the message but just to leave the prefix inplace.
-	(void) nng_msg_trim(msg, sizeof(msg));
+	(void) nng_msg_trim(msg, sizeof(*msg));
 
 	return (nng_msg_body(msg));
 }
@@ -375,7 +375,7 @@ nn_reallocmsg(void *ptr, size_t len)
 	}
 	// Stash the msg header pointer
 	*(nng_msg **) (nng_msg_body(msg)) = msg;
-	nng_msg_trim(msg, sizeof(msg));
+	nng_msg_trim(msg, sizeof(*msg));
 	return (nng_msg_body(msg));
 }
 
@@ -458,12 +458,12 @@ nn_recvmsg(int s, struct nn_msghdr *mh, int flags)
 	if ((mh->msg_iovlen == 1) && (mh->msg_iov[0].iov_len == NN_MSG)) {
 		// Receiver wants to have a dynamically allocated message.
 		// There can only be one of these.
-		if ((rv = nng_msg_insert(msg, &msg, sizeof(msg))) != 0) {
+		if ((rv = nng_msg_insert(msg, &msg, sizeof(*msg))) != 0) {
 			nng_msg_free(msg);
 			nn_seterror(rv);
 			return (-1);
 		}
-		nng_msg_trim(msg, sizeof(msg));
+		nng_msg_trim(msg, sizeof(*msg));
 		*(void **) (mh->msg_iov[0].iov_base) = nng_msg_body(msg);
 		len                                  = nng_msg_len(msg);
 		keep = 1; // Do not discard message!
@@ -520,7 +520,7 @@ nn_recvmsg(int s, struct nn_msghdr *mh, int flags)
 				return (-1);
 			}
 			memcpy(nng_msg_body(nmsg), &nmsg, sizeof(nmsg));
-			nng_msg_trim(nmsg, sizeof(nmsg));
+			nng_msg_trim(nmsg, sizeof(*nmsg));
 			cdata                      = nng_msg_body(nmsg);
 			*(void **) mh->msg_control = cdata;
 			tlen                       = clen;


### PR DESCRIPTION
The operand to sizeof is the same as the pointer in a memory access. The developer likely intended to calculate the size of the object pointed to but forgot to dereference the pointer in the sizeof. The following code locations use the size of a pointer instead of the actual object's size:
---

5 instances of this defect were found in the following locations:
---
**Instance 1**
File : `src/compat/nanomsg/nn.c` 
Function: `nng_msg_trim` 
https://github.com/siva-msft/nng/blob/298974029bd6fa68d175af1ba8580e1d76a386f8/src/compat/nanomsg/nn.c#L339
Code extract:

```cpp

	// We are counting on the implementation of nn_msg_trim to not
	// reallocate the message but just to leave the prefix inplace.
	(void) nng_msg_trim(msg, sizeof(msg)); <------ HERE

	return (nng_msg_body(msg));
```

---
**Instance 2**
File : `src/compat/nanomsg/nn.c` 
Function: `nng_msg_trim` 
https://github.com/siva-msft/nng/blob/298974029bd6fa68d175af1ba8580e1d76a386f8/src/compat/nanomsg/nn.c#L378
Code extract:

```cpp
	}
	// Stash the msg header pointer
	*(nng_msg **) (nng_msg_body(msg)) = msg;
	nng_msg_trim(msg, sizeof(msg)); <------ HERE
	return (nng_msg_body(msg));
}
```

---
**Instance 3**
File : `src/compat/nanomsg/nn.c` 
Function: `nng_msg_insert` 
https://github.com/siva-msft/nng/blob/298974029bd6fa68d175af1ba8580e1d76a386f8/src/compat/nanomsg/nn.c#L461
Code extract:

```cpp
	if ((mh->msg_iovlen == 1) && (mh->msg_iov[0].iov_len == NN_MSG)) {
		// Receiver wants to have a dynamically allocated message.
		// There can only be one of these.
		if ((rv = nng_msg_insert(msg, &msg, sizeof(msg))) != 0) { <------ HERE
			nng_msg_free(msg);
			nn_seterror(rv);
```

---
**Instance 4**
File : `src/compat/nanomsg/nn.c` 
Function: `nng_msg_trim` 
https://github.com/siva-msft/nng/blob/298974029bd6fa68d175af1ba8580e1d76a386f8/src/compat/nanomsg/nn.c#L466
Code extract:

```cpp
			nn_seterror(rv);
			return (-1);
		}
		nng_msg_trim(msg, sizeof(msg)); <------ HERE
		*(void **) (mh->msg_iov[0].iov_base) = nng_msg_body(msg);
		len                                  = nng_msg_len(msg);
```

---
**Instance 5**
File : `src/compat/nanomsg/nn.c` 
Function: `nng_msg_trim` 
https://github.com/siva-msft/nng/blob/298974029bd6fa68d175af1ba8580e1d76a386f8/src/compat/nanomsg/nn.c#L523
Code extract:

```cpp
				return (-1);
			}
			memcpy(nng_msg_body(nmsg), &nmsg, sizeof(nmsg));
			nng_msg_trim(nmsg, sizeof(nmsg)); <------ HERE
			cdata                      = nng_msg_body(nmsg);
			*(void **) mh->msg_control = cdata;
```

